### PR TITLE
Check nullifier after sending vote

### DIFF
--- a/pages/staging/components/voting_booth.tsx
+++ b/pages/staging/components/voting_booth.tsx
@@ -201,12 +201,19 @@ const VotingBooth = ({ proc, onBackNavigation, onVote, onError }) => {
                 });
 
             VotingApi.submitEnvelope(envelope, signature, pool)
-                .then(() => {
+                .then(async () => {
                     const nullifier = VotingApi.getSignedVoteNullifier(
                         wallet.address,
                         proc.id
                     );
-                    onVote(nullifier);
+                    for (let i = 0; i < 10; i++) {
+                        const { registered, date } = await VotingApi.getEnvelopeStatus(proc.id, nullifier, pool)
+                        if (registered) {
+                            return onVote(nullifier)
+                        }
+                        await new Promise((resolve) => setTimeout(resolve, Math.floor(process.env.BLOCK_TIME * 500)))
+                    }
+                    throw new Error("check nullifier error")
                 })
                 .catch((err) => {
                     onError(err);

--- a/pages/staging/index.tsx
+++ b/pages/staging/index.tsx
@@ -31,7 +31,7 @@ const IndexPage = () => {
     };
 
     useEffect(() => {
-        if (message == null) return;
+        if (message === null) return;
 
         let msg: string
         if ((message as any) instanceof Error) msg = (message as any).message
@@ -40,6 +40,7 @@ const IndexPage = () => {
 
         if (msg.includes("certificate already used")) return alert("El teu certificat ja ha estat utilitzat per aquest procés")
         else if (msg.includes("Could not fetch the process")) return alert("No es poden carregar les dades del procés. Intenta-ho de nou en uns minuts.")
+        else if (msg.includes("nullifier error")) return alert("Hi ha hagut un problema enregistrant el teu vot")
 
         alert("Hi ha hagut un error en processar la petició");
         console.error(msg);


### PR DESCRIPTION
Check the nullifier after a vote has been sent, to ensure the vote is actually registered in the blockchain.